### PR TITLE
Initial commit activating NGS within neutron, along with configmap for OSODZ Live

### DIFF
--- a/argocd/clusters/managed-clusters/dzoso/live/openstack-ctlplane/templates/controlplane.yaml
+++ b/argocd/clusters/managed-clusters/dzoso/live/openstack-ctlplane/templates/controlplane.yaml
@@ -314,6 +314,36 @@ spec:
         dns_servers = 172.18.150.244,172.18.150.245,172.18.150.246
         [ml2_type_vlan]
         network_vlan_ranges = az1-vlan:1:999,az2-vlan:1:999,az3-vlan:1:999,datacentre:1:999,bgp-physnet:1:3999
+        # Added for NGS - ANDREW - CHECK TO CONFIRM?
+        [ml2]
+        mechanism_drivers = ovn,genericswitch,vlan
+      extraMounts:
+        - name: ml2-ngs
+          mountPath: /etc/neutron/plugins/ml2.d/20-ml2-ngs.conf
+          subPath: 20-ml2-ngs.conf
+          configMap:
+            name: neutron-ml2-ngs
+      extraEnvVars:
+        - name: SW1_USER
+          valueFrom:
+            secretKeyRef: oso-ngs-secret
+              name: oso-ngs-secret
+              key: SW1_USER
+        - name: SW1_PASS
+          valueFrom:
+            secretKeyRef: oso-ngs-secret
+              name: oso-ngs-secret
+              key: SW1_PASS
+        - name: SW2_USER
+          valueFrom:
+            secretKeyRef: oso-ngs-secret
+              name: oso-ngs-secret
+              key: SW2_USER
+        - name: SW2_PASS
+          valueFrom:
+            secretKeyRef: oso-ngs-secret
+              name: oso-ngs-secret
+              key: SW2_PASS
       networkAttachments:
       - internalapi
 

--- a/argocd/clusters/managed-clusters/dzoso/live/openstack-ctlplane/templates/neutron-ngs-configmap.yaml
+++ b/argocd/clusters/managed-clusters/dzoso/live/openstack-ctlplane/templates/neutron-ngs-configmap.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: neutron-ml2-ngs
+  namespace: openstack
+data:
+  20-ml2-ngs.conf: |
+    [ml2]
+    mechanism_drivers = ovn,genericswitch
+
+    [genericswitch]
+    # Optional global defaults (timeouts, etc.)
+
+    # Example switch #1
+    [genericswitch:switch-core-1]
+    device_type = netmiko_sonic
+    ip = 172.18.1.5
+    username = ${SW1_USER}
+    password = ${SW1_PASS}
+    # Map Neutron ports to physical switch interfaces
+    interface_mapping = \
+      ilo-hp-blade-2-port-A:Ethernet80, \
+      ilo-hp-blade-4-port-A:Ethernet84, \
+      ilo-hp-blade-6-port-A:Ethernet88, \
+      ilo-hp-blade-8-port-A:Ethernet92
+
+    # Example switch #2
+    [genericswitch:switch-core-2]
+    device_type = netmiko_sonic
+    ip = 172.18.1.6
+    username = ${SW2_USER}
+    password = ${SW2_PASS}
+    interface_mapping = \
+      ilo-hp-blade-2-port-B:Ethernet80, \
+      ilo-hp-blade-4-port-B:Ethernet84, \
+      ilo-hp-blade-6-port-B:Ethernet88, \
+      ilo-hp-blade-8-port-B:Ethernet92

--- a/argocd/clusters/managed-clusters/dzoso/live/openstack-ctlplane/templates/neutron-ngs-secret.yaml
+++ b/argocd/clusters/managed-clusters/dzoso/live/openstack-ctlplane/templates/neutron-ngs-secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.cloudName }}-ngs-secret
+  namespace: openstack
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault
+  target:
+    name: {{ .Values.cloudName }}-ngs-secret
+    creationPolicy: Owner
+  dataFrom:
+  - extract:
+      key: {{ .Values.externalRegistrySecret }}


### PR DESCRIPTION
Initial commit activating NGS within neutron, along with configmap for OSODZ Live - NGS ml2.conf and secret via ESO - already set in Vault - and updates to neutron controlplane.yaml to enable it.. Probably doesnt work, need to check ml2 types